### PR TITLE
Update README.md file to correct command for starting mariadb service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ sudo systemctl enable firewalld
 ```
 sudo yum install -y mariadb-server
 sudo vi /etc/my.cnf
-sudo service mariadb start
+#sudo service mariadb start     --not working
+sudo systemctl start mariadb    --added this
 sudo systemctl enable mariadb
 ```
 


### PR DESCRIPTION

![Screenshot 2023-09-03 111444](https://github.com/sanjusjk/learning-app-ecommerce/assets/26535858/ea3dc05b-e8ea-446f-b2eb-995b4d8d3683)

added changes with respect to starting mariadb service using systemctl in section 'Install MariaDB'

removed(commented):   sudo service mariadb start
added:    sudo systemctl start mariadb